### PR TITLE
SoAの二次元配列版を作成

### DIFF
--- a/pd/Makefile
+++ b/pd/Makefile
@@ -1,5 +1,5 @@
 AOS = aos_pair.out aos_next.out aos_sorted.out aos_intrin_v1.out aos_intrin_v2.out aos_intrin_v3.out aos_intrin_v4.out aos_intrin_v5.out aos_intrin_v1_reactless.out aos_intrin_v2_reactless.out aos_intrin_v3_reactless.out
-SOA = soa_pair.out soa_sorted.out soa_next.out soa_intrin_v1.out soa_intrin_v2.out soa_intrin_v3.out
+SOA = soa_pair.out soa_sorted.out soa_next.out soa_intrin_v1.out soa_intrin_v2.out soa_intrin_v3.out soa_sorted_2d.out
 LOOP_DEP = knl_1x8_aos_v1.out knl_1x8_aos_v2.out knl_1x8_aos_v3.out knl_1x8_soa_v1.out knl_ref_aos.out knl_ref_soa.out
 BENCH = aos_bench.out soa_bench.out
 
@@ -62,6 +62,9 @@ soa_pair.out: force_soa.cpp
 
 soa_sorted.out: force_soa.cpp
 	icpc -O3 -xMIC-AVX512 -std=c++11 -DSORTED $< -o $@
+
+soa_sorted_2d.out: force_soa.cpp
+	icpc -O3 -xMIC-AVX512 -std=c++11 -DSORTED_2D $< -o $@
 
 soa_next.out: force_soa.cpp
 	icpc -O3 -xMIC-AVX512 -std=c++11 -DNEXT $< -o $@
@@ -127,11 +130,13 @@ test_soa: $(SOA)
 	./soa_pair.out > soa_pair.dat
 	./soa_next.out > soa_next.dat
 	./soa_sorted.out > soa_sorted.dat
+	./soa_sorted_2d.out > soa_sorted_2d.dat
 	./soa_intrin_v1.out > soa_intrin_v1.dat
 	./soa_intrin_v2.out > soa_intrin_v2.dat
 	./soa_intrin_v3.out > soa_intrin_v3.dat
 	diff soa_pair.dat soa_sorted.dat
 	diff soa_sorted.dat soa_next.dat
+	diff soa_sorted.dat soa_sorted_2d.dat
 	diff soa_next.dat soa_intrin_v1.dat
 	diff soa_intrin_v1.dat soa_intrin_v2.dat
 	diff soa_intrin_v2.dat soa_intrin_v3.dat


### PR DESCRIPTION
SoA版を、二次元配列で実装したところ、自動SIMD化がうまくいって、それなりの速度が出ました。
具体的には
```
double q[D][N];
double p[D][N];
```
というSoA型の二次元配列を定義し、`force_sorted`をその配列で計算する`force_sorted_2d`を`force_soa.cpp`に追加しました。速度はそれぞれ

* density = 1.0
    * N=119164, sorted_2d 10631 [ms]
* density = 0.5
    * N=62500, sorted_2d 3109 [ms]

と、手でSIMD化した最速実装にかなり近い性能が出ています。
アセンブリ見ると、gather、scatterを使っており、さらに逆数近似と精度補正もやってるみたいです。