### PR TITLE
SoAの8要素パック版を作成

### DIFF
--- a/pd/Makefile
+++ b/pd/Makefile
@@ -1,4 +1,4 @@
-AOS = aos_pair.out aos_next.out aos_sorted.out aos_intrin_v1.out aos_intrin_v2.out aos_intrin_v3.out aos_intrin_v4.out aos_intrin_v5.out aos_intrin_v1_reactless.out aos_intrin_v2_reactless.out aos_intrin_v3_reactless.out
+AOS = aos_pair.out aos_next.out aos_sorted.out aos_intrin_v1.out aos_intrin_v2.out aos_intrin_v3.out aos_intrin_v4.out aos_intrin_v5.out aos_intrin_v1_reactless.out aos_intrin_v2_reactless.out aos_intrin_v3_reactless.out aos_8.out aos_8_swp.out
 SOA = soa_pair.out soa_sorted.out soa_next.out soa_intrin_v1.out soa_intrin_v2.out soa_intrin_v3.out soa_sorted_2d.out
 LOOP_DEP = knl_1x8_aos_v1.out knl_1x8_aos_v2.out knl_1x8_aos_v3.out knl_1x8_soa_v1.out knl_ref_aos.out knl_ref_soa.out
 BENCH = aos_bench.out soa_bench.out
@@ -41,6 +41,12 @@ aos_intrin_v4.out: force_aos.cpp
 
 aos_intrin_v5.out: force_aos.cpp
 	icpc -O3 -qopt-prefetch=4 -xMIC-AVX512 -std=c++11 -DINTRIN_v5 $< -o $@
+
+aos_8.out: force_aos.cpp
+	icpc -O3 -qopt-prefetch=4 -xMIC-AVX512 -std=c++11 -DAOS_8 $< -o $@
+
+aos_8_swp.out: force_aos.cpp
+	icpc -O3 -qopt-prefetch=4 -xMIC-AVX512 -std=c++11 -DAOS_8_SWP $< -o $@
 
 aos_bench.out: force_aos.cpp
 	icpc -O3 -qopt-prefetch=4 -xMIC-AVX512 -std=c++11 $< -o $@

--- a/pd/force_soa.cpp
+++ b/pd/force_soa.cpp
@@ -9,8 +9,8 @@
 #include <x86intrin.h>
 #include <sys/stat.h>
 //----------------------------------------------------------------------
-// const double density = 1.0;
-const double density = 0.5;
+ const double density = 1.0;
+// const double density = 0.5;
 const int N = 400000;
 const int MAX_PAIRS = 30 * N;
 const double L = 50.0;

--- a/pd/profile/phi_7250_raw.dat
+++ b/pd/profile/phi_7250_raw.dat
@@ -14,6 +14,8 @@ N=119164, without scatter & gather, swp                   11508 [ms]
 N=119164, with gather, reactless                          12154 [ms]
 N=119164, without gather, reactless                       18046 [ms]
 N=119164, with gather, reactless, remaining loop opt      11634 [ms]
+N=119164, aos 8 bytes, intrin                             11318 [ms]
+N=119164, aos 8 bytes, intrin, swp                        10073 [ms]
 
 ## density = 0.5
 N=62500, pair                                              9946 [ms]


### PR DESCRIPTION
AoS版(`force_aos.cpp`)に、

```
double z[N][8];
```

という形の配列でデータを持って、運動量と座標の8要素(実質6要素)を一度にloadするコードを作成しました。

そのまま実装したのが`force_sorted_z_intrin (aos_8.out)`で、少しだけソフトウェアパイプライニングしたものが`force_sorted_z_intrin_swp (aos_8_swp.out)`です。

低密度(0.5)では遅いですが、高密度(1.0)ではAoSの最速コード(`aos_intrin_v3.out`)と同等程度の速度が出ます。真面目にSWPしてないので、そこをちゃんとやればもう少し早くなると思います。